### PR TITLE
Support old API key based auth

### DIFF
--- a/lib/monkey_business.rb
+++ b/lib/monkey_business.rb
@@ -21,6 +21,7 @@ module MonkeyBusiness
   class API
     def initialize
       @access_token = ENV['SURVEYMONKEY_ACCESS_TOKEN']
+      @api_key = ENV['SURVEYMONKEY_API_KEY']
     end
 
     def surveys(options = {})
@@ -74,9 +75,24 @@ module MonkeyBusiness
     def request(resource_path, options = {})
       HttpRequest.request(
         @access_token,
-        BASE_URI + resource_path,
+        format_uri(resource_path),
         options
       )
+    end
+
+    private
+
+    def format_uri(resource_path)
+      uri = URI(BASE_URI + resource_path)
+      uri.query = encode_query_params(uri.query)
+      uri.to_s
+    end
+
+    def encode_query_params(query)
+      extra_params = {}
+      extra_params[:api_key] = @api_key if @api_key
+      new_params = URI.decode_www_form(query.to_s).concat(extra_params.to_a)
+      URI.encode_www_form(new_params)
     end
   end
 end


### PR DESCRIPTION
This PR adds support for [OLD Authentication](https://developer.surveymonkey.com/api/v3/#old-authentication).

### Why it might be necessary
When people start migrating their old application from SurveyMonkey API V2 to V3, they might need to use the old auth. Specially if same authentication is being used by multiple apps and business doesn't want to break other application right away.